### PR TITLE
Purge

### DIFF
--- a/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
@@ -5,8 +5,10 @@ import BasicLayout from 'main/layouts/BasicLayout/BasicLayout';
 import EarthquakesTable from 'main/components/Earthquakes/EarthquakesTable';
 import { useCurrentUser } from 'main/utils/currentUser';
 import { useBackendMutation } from 'main/utils/useBackend';
+import { Button } from 'react-bootstrap';
+import { onDeleteSuccess } from 'main/utils/EarthquakesUtils';
 
-export default function EarthquakesIndexPage() {
+export default function EarthquakesIndexPage({ buttonLabel = 'Purge' }) {
   const currentUser = useCurrentUser();
 
   const {
@@ -20,25 +22,36 @@ export default function EarthquakesIndexPage() {
     []
   );
 
-  // const objectToAxiosParams = () => ({
-  //   url: '/api/earthquakes/purge',
-  //   method: 'POST',
-  // });
+  const objectToAxiosParams = () => ({
+    url: '/api/earthquakes/purge',
+    method: 'POST',
+  });
 
-  // const deleteMutation = useBackendMutation(
-  //   objectToAxiosParams,
-  //   { onSuccess: onDeleteSuccess },
-  //   ['/api/earthquakes/purge']
-  // );
-  // const deleteCallback = async (data) => {
-  //   deleteMutation.mutate(data);
-  // };
-  //<button onClick={deleteCallback}>Purge</button>;
+  const deleteMutation = useBackendMutation(
+    objectToAxiosParams,
+    {
+      onSuccess: () => onDeleteSuccess('Earthquakes have been purged'),
+    },
+    ['/api/earthquakes/all']
+  );
+
+  const deleteCallback = async (data) => {
+    deleteMutation.mutate(data);
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>Earthquakes</h1>
         <EarthquakesTable earthquakes={earthquakes} currentUser={currentUser} />
+        <Button
+          variant="danger"
+          data-testid="EarthquakesIndex-purge"
+          type="submit"
+          onClick={deleteCallback}
+        >
+          {buttonLabel}
+        </Button>
       </div>
     </BasicLayout>
   );

--- a/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesIndexPage.js
@@ -8,7 +8,7 @@ import { useBackendMutation } from 'main/utils/useBackend';
 import { Button } from 'react-bootstrap';
 import { onDeleteSuccess } from 'main/utils/EarthquakesUtils';
 
-export default function EarthquakesIndexPage({ buttonLabel = 'Purge' }) {
+export default function EarthquakesIndexPage() {
   const currentUser = useCurrentUser();
 
   const {
@@ -32,6 +32,7 @@ export default function EarthquakesIndexPage({ buttonLabel = 'Purge' }) {
     {
       onSuccess: () => onDeleteSuccess('Earthquakes have been purged'),
     },
+    // Stryker disable next-line all : hard to set up test for caching
     ['/api/earthquakes/all']
   );
 
@@ -47,10 +48,9 @@ export default function EarthquakesIndexPage({ buttonLabel = 'Purge' }) {
         <Button
           variant="danger"
           data-testid="EarthquakesIndex-purge"
-          type="submit"
           onClick={deleteCallback}
         >
-          {buttonLabel}
+          Purge
         </Button>
       </div>
     </BasicLayout>

--- a/frontend/src/main/utils/EarthquakesUtils.js
+++ b/frontend/src/main/utils/EarthquakesUtils.js
@@ -1,0 +1,7 @@
+import { toast } from 'react-toastify';
+import { useNavigate } from 'react-router-dom';
+
+export function onDeleteSuccess(message) {
+  console.log(message);
+  toast(message);
+}

--- a/frontend/src/tests/components/UCSBSubjectsTest/UCSBSubjectsTable.test.js
+++ b/frontend/src/tests/components/UCSBSubjectsTest/UCSBSubjectsTable.test.js
@@ -1,30 +1,28 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
-import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
-import UCSBSubjectsTable from "main/components/UCSBSubjects/UCSBSubjectsTable"
-import { QueryClient, QueryClientProvider } from "react-query";
-import { MemoryRouter } from "react-router-dom";
-import { currentUserFixtures } from "fixtures/currentUserFixtures";
-
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import { ucsbSubjectsFixtures } from 'fixtures/ucsbSubjectsFixtures';
+import UCSBSubjectsTable from 'main/components/UCSBSubjects/UCSBSubjectsTable';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { currentUserFixtures } from 'fixtures/currentUserFixtures';
 
 const mockedNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => ({
-    ...jest.requireActual('react-router-dom'),
-    useNavigate: () => mockedNavigate
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockedNavigate,
 }));
 
 const mockedMutate = jest.fn();
 
 jest.mock('main/utils/useBackend', () => ({
-    ...jest.requireActual('main/utils/useBackend'),
-    useBackendMutation: () => ({mutate: mockedMutate})
+  ...jest.requireActual('main/utils/useBackend'),
+  useBackendMutation: () => ({ mutate: mockedMutate }),
 }));
 
-describe("UserTable tests", () => {
+describe('UserTable tests', () => {
   const queryClient = new QueryClient();
 
-
-  test("renders without crashing for empty table with user not logged in", () => {
+  test('renders without crashing for empty table with user not logged in', () => {
     const currentUser = null;
 
     render(
@@ -33,10 +31,9 @@ describe("UserTable tests", () => {
           <UCSBSubjectsTable subjects={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
   });
-  test("renders without crashing for empty table for ordinary user", () => {
+  test('renders without crashing for empty table for ordinary user', () => {
     const currentUser = currentUserFixtures.userOnly;
 
     render(
@@ -45,11 +42,10 @@ describe("UserTable tests", () => {
           <UCSBSubjectsTable subjects={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
   });
 
-  test("renders without crashing for empty table for admin", () => {
+  test('renders without crashing for empty table for admin', () => {
     const currentUser = currentUserFixtures.adminUser;
 
     render(
@@ -58,26 +54,42 @@ describe("UserTable tests", () => {
           <UCSBSubjectsTable subjects={[]} currentUser={currentUser} />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
   });
 
-  test("Has the expected colum headers and content for adminUser", () => {
-
+  test('Has the expected colum headers and content for adminUser', () => {
     const currentUser = currentUserFixtures.adminUser;
 
     const { getByText, getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBSubjectsTable subjects={ucsbSubjectsFixtures.threeSubjects} currentUser={currentUser} />
+          <UCSBSubjectsTable
+            subjects={ucsbSubjectsFixtures.threeSubjects}
+            currentUser={currentUser}
+          />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
-    const expectedHeaders = ["id", "SubjectCode", "SubjectTranslation", "DeptCode", "CollegeCode", "RelatedDeptCode", "Inactive"];
-    const expectedFields = ["id", "subjectCode", "subjectTranslation", "deptCode", "collegeCode", "relatedDeptCode", "inactive"];
-    const testId = "UCSBSubjectsTable";
+    const expectedHeaders = [
+      'id',
+      'SubjectCode',
+      'SubjectTranslation',
+      'DeptCode',
+      'CollegeCode',
+      'RelatedDeptCode',
+      'Inactive',
+    ];
+    const expectedFields = [
+      'id',
+      'subjectCode',
+      'subjectTranslation',
+      'deptCode',
+      'collegeCode',
+      'relatedDeptCode',
+      'inactive',
+    ];
+    const testId = 'UCSBSubjectsTable';
 
     expectedHeaders.forEach((headerText) => {
       const header = getByText(headerText);
@@ -89,69 +101,77 @@ describe("UserTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent("1");
-    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent("2");
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent('1');
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent('2');
 
     const editButton = getByTestId(`${testId}-cell-row-0-col-Edit-button`);
     expect(editButton).toBeInTheDocument();
-    expect(editButton).toHaveClass("btn-primary");
+    expect(editButton).toHaveClass('btn-primary');
 
     const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
     expect(deleteButton).toBeInTheDocument();
-    expect(deleteButton).toHaveClass("btn-danger");
-
+    expect(deleteButton).toHaveClass('btn-danger');
   });
 
-  
-
-  test("Edit button navigates to the edit page for admin user", async () => {
-
+  test('Edit button navigates to the edit page for admin user', async () => {
     const currentUser = currentUserFixtures.adminUser;
 
     const { getByText, getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBSubjectsTable subjects={ucsbSubjectsFixtures.threeSubjects} currentUser={currentUser} />
+          <UCSBSubjectsTable
+            subjects={ucsbSubjectsFixtures.threeSubjects}
+            currentUser={currentUser}
+          />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
-    await waitFor(() => { expect(getByTestId(`UCSBSubjectsTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+    await waitFor(() => {
+      expect(
+        getByTestId(`UCSBSubjectsTable-cell-row-0-col-id`)
+      ).toHaveTextContent('1');
+    });
 
-    const editButton = getByTestId(`UCSBSubjectsTable-cell-row-0-col-Edit-button`);
+    const editButton = getByTestId(
+      `UCSBSubjectsTable-cell-row-0-col-Edit-button`
+    );
     expect(editButton).toBeInTheDocument();
-    
+
     fireEvent.click(editButton);
 
-    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/UCSBSubjects/edit/1'));
-
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith('/UCSBSubjects/edit/1')
+    );
   });
 
-  test("Delete button calls the delete call back", async () => {
-
+  test('Delete button calls the delete call back', async () => {
     const currentUser = currentUserFixtures.adminUser;
 
     const { getByText, getByTestId } = render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <UCSBSubjectsTable subjects={ucsbSubjectsFixtures.threeSubjects} currentUser={currentUser} />
+          <UCSBSubjectsTable
+            subjects={ucsbSubjectsFixtures.threeSubjects}
+            currentUser={currentUser}
+          />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
-    await waitFor(() => { expect(getByTestId(`UCSBSubjectsTable-cell-row-0-col-id`)).toHaveTextContent("1"); });
+    await waitFor(() => {
+      expect(
+        getByTestId(`UCSBSubjectsTable-cell-row-0-col-id`)
+      ).toHaveTextContent('1');
+    });
 
-    const deleteButton = getByTestId(`UCSBSubjectsTable-cell-row-0-col-Delete-button`);
+    const deleteButton = getByTestId(
+      `UCSBSubjectsTable-cell-row-0-col-Delete-button`
+    );
     expect(deleteButton).toBeInTheDocument();
-    
+
     fireEvent.click(deleteButton);
 
     await waitFor(() => expect(mockedMutate).toHaveBeenCalledTimes(1));
-
-
   });
-
 });
-

--- a/frontend/src/tests/pages/EarthquakesTest/EarthquakesIndexPage.test.js
+++ b/frontend/src/tests/pages/EarthquakesTest/EarthquakesIndexPage.test.js
@@ -156,16 +156,16 @@ describe('EarthquakesIndexPage tests', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('test what happens when you click purge, admin', async () => {
+  test('test what happens when you click purge', async () => {
     setupAdminUser();
 
     const queryClient = new QueryClient();
     axiosMock
-      .onGet('/api/Earthquakes/all')
+      .onGet('/api/earthquakes/all')
       .reply(200, earthquakesFixtures.twoEarthquakes);
     axiosMock
-      .onDelete('/api/Earthquakes')
-      .reply(200, 'UCSBSubject with id 1 was deleted');
+      .onDelete('/api/earthquakes/purge')
+      .reply(200, 'Earthquakes have been purged');
 
     const { getByTestId } = render(
       <QueryClientProvider client={queryClient}>
@@ -179,15 +179,47 @@ describe('EarthquakesIndexPage tests', () => {
       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent('1');
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      'abcd1234abcd1234abcd1234'
+    );
+    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      'abcd5678abcd5678abcd5678'
+    );
+    expect(getByTestId(`${testId}-cell-row-0-col-title`)).toHaveTextContent(
+      'M 2.2 - 10km ESE of Ojai, CA'
+    );
+    expect(getByTestId(`${testId}-cell-row-1-col-title`)).toHaveTextContent(
+      'M 6.9 - 21km S of Cupertino, CA'
+    );
+    expect(getByTestId(`${testId}-cell-row-0-col-mag`)).toHaveTextContent(
+      '2.16'
+    );
+    expect(getByTestId(`${testId}-cell-row-1-col-mag`)).toHaveTextContent(
+      '6.9'
+    );
+    expect(getByTestId(`${testId}-cell-row-0-col-place`)).toHaveTextContent(
+      '10km ESE of Ojai, CA'
+    );
+    expect(getByTestId(`${testId}-cell-row-1-col-place`)).toHaveTextContent(
+      '21km S of Cupertino, CA'
+    );
+    expect(getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent(
+      '1644571919000'
+    );
+    expect(getByTestId(`${testId}-cell-row-1-col-time`)).toHaveTextContent(
+      '1844531919000'
+    );
 
-    const deleteButton = getByTestId(`${testId}-cell-row-0-col-Delete-button`);
+    const deleteButton = getByTestId('EarthquakesIndex-purge');
     expect(deleteButton).toBeInTheDocument();
 
     fireEvent.click(deleteButton);
 
-    await waitFor(() => {
-      expect(mockToast).toBeCalledWith('UCSBSubject with id 1 was deleted');
-    });
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+    expect(getByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    await waitFor(() => expect(mockedMutate).toHaveBeenCalledTimes(1));
+
+    //expect(mockToast).toBeCalledWith('Earthquakes have been purged');
   });
 });

--- a/frontend/src/tests/pages/EarthquakesTest/EarthquakesIndexPage.test.js
+++ b/frontend/src/tests/pages/EarthquakesTest/EarthquakesIndexPage.test.js
@@ -155,8 +155,8 @@ describe('EarthquakesIndexPage tests', () => {
       queryByTestId(`${testId}-cell-row-0-col-id`)
     ).not.toBeInTheDocument();
   });
-  /** 
-  test('test what happens when you click delete, admin', async () => {
+
+  test('test what happens when you click purge, admin', async () => {
     setupAdminUser();
 
     const queryClient = new QueryClient();
@@ -190,5 +190,4 @@ describe('EarthquakesIndexPage tests', () => {
       expect(mockToast).toBeCalledWith('UCSBSubject with id 1 was deleted');
     });
   });
-  */
 });

--- a/frontend/src/tests/pages/EarthquakesTest/EarthquakesIndexPage.test.js
+++ b/frontend/src/tests/pages/EarthquakesTest/EarthquakesIndexPage.test.js
@@ -158,14 +158,11 @@ describe('EarthquakesIndexPage tests', () => {
 
   test('test what happens when you click purge', async () => {
     setupAdminUser();
-
     const queryClient = new QueryClient();
     axiosMock
       .onGet('/api/earthquakes/all')
       .reply(200, earthquakesFixtures.twoEarthquakes);
-    axiosMock
-      .onDelete('/api/earthquakes/purge')
-      .reply(200, 'Earthquakes have been purged');
+    axiosMock.onPost('/api/earthquakes/purge').reply(200);
 
     const { getByTestId } = render(
       <QueryClientProvider client={queryClient}>
@@ -179,47 +176,16 @@ describe('EarthquakesIndexPage tests', () => {
       expect(getByTestId(`${testId}-cell-row-0-col-id`)).toBeInTheDocument();
     });
 
-    expect(getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-      'abcd1234abcd1234abcd1234'
-    );
-    expect(getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
-      'abcd5678abcd5678abcd5678'
-    );
-    expect(getByTestId(`${testId}-cell-row-0-col-title`)).toHaveTextContent(
-      'M 2.2 - 10km ESE of Ojai, CA'
-    );
-    expect(getByTestId(`${testId}-cell-row-1-col-title`)).toHaveTextContent(
-      'M 6.9 - 21km S of Cupertino, CA'
-    );
-    expect(getByTestId(`${testId}-cell-row-0-col-mag`)).toHaveTextContent(
-      '2.16'
-    );
-    expect(getByTestId(`${testId}-cell-row-1-col-mag`)).toHaveTextContent(
-      '6.9'
-    );
-    expect(getByTestId(`${testId}-cell-row-0-col-place`)).toHaveTextContent(
-      '10km ESE of Ojai, CA'
-    );
-    expect(getByTestId(`${testId}-cell-row-1-col-place`)).toHaveTextContent(
-      '21km S of Cupertino, CA'
-    );
-    expect(getByTestId(`${testId}-cell-row-0-col-time`)).toHaveTextContent(
-      '1644571919000'
-    );
-    expect(getByTestId(`${testId}-cell-row-1-col-time`)).toHaveTextContent(
-      '1844531919000'
-    );
-
     const deleteButton = getByTestId('EarthquakesIndex-purge');
     expect(deleteButton).toBeInTheDocument();
 
     fireEvent.click(deleteButton);
 
-    await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+    await waitFor(() => expect(axiosMock.history.post.length).toBe(1)); //checks that post was called
 
-    expect(getByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
-    await waitFor(() => expect(mockedMutate).toHaveBeenCalledTimes(1));
-
-    //expect(mockToast).toBeCalledWith('Earthquakes have been purged');
+    await waitFor(() => expect(mockToast).toBeCalled); //toastify is called only when backend mutation onDelete is successfully called
+    expect(mockToast).toBeCalledWith('Earthquakes have been purged');
+    //we don't check that the table is cleared as the purge calls get again to update the table without refresh. however, in the test is calls
+    //for axios to re-insert twoEarthquakes
   });
 });

--- a/frontend/src/tests/utils/EarthquakesUtils.test.js
+++ b/frontend/src/tests/utils/EarthquakesUtils.test.js
@@ -1,0 +1,49 @@
+import { onDeleteSuccess } from 'main/utils/EarthquakesUtils';
+import mockConsole from 'jest-mock-console';
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+  const originalModule = jest.requireActual('react-toastify');
+  return {
+    __esModule: true,
+    ...originalModule,
+    toast: (x) => mockToast(x),
+  };
+});
+
+describe('EarthquakesUtils', () => {
+  describe('onDeleteSuccess', () => {
+    test('It puts the message on console.log and in a toast', () => {
+      // arrange
+      const restoreConsole = mockConsole();
+
+      // act
+      onDeleteSuccess('abc');
+
+      // assert
+      expect(mockToast).toHaveBeenCalledWith('abc');
+      expect(console.log).toHaveBeenCalled();
+      const message = console.log.mock.calls[0][0];
+      expect(message).toMatch('abc');
+
+      restoreConsole();
+    });
+  });
+  // describe("editCallback", () => {
+
+  //     test("It pops up the expected toast", () => {
+  //         // arrange
+  //         const cell = { row: { values: { id: 17, name: "Groundhog Day" } } };
+  //         const expectedToast =  `Edit Callback called on id: 17 name: Groundhog Day`
+
+  //         // act
+  //         const result = editCallback(cell);
+
+  //         // assert
+
+  //         expect(mockToast).toHaveBeenCalledWith(expectedToast);
+
+  //     });
+
+  // });
+});


### PR DESCRIPTION
# Overview

In this PR, we implement the purge button on the Earthquakes list site and its tests. The purge button will call the post method and delete all earthquakes before updating the list to show an empty list. Then, a toastify message will pop up showing that the action has been completed.

# Issues Addressed

Closes #30 
